### PR TITLE
Fix 3.21 - Error crear y editar un Job/414 DONE

### DIFF
--- a/backend/service/views.py
+++ b/backend/service/views.py
@@ -89,6 +89,8 @@ class JobView(APIView):
         estimated_price = job_data['estimated_price']
         if estimated_price == '':
             estimated_price = 10
+        if isinstance(estimated_price, int):
+            estimated_price = estimated_price + 0.001
         if not isinstance(estimated_price, float):
             raise ValidationError('El precio estimado debe ser un número')
         job = Job.objects.create(service=service, name=name, estimated_price=estimated_price)
@@ -115,10 +117,8 @@ class JobView(APIView):
         new_estimated_price = job_data['estimated_price']
         if new_estimated_price == '':
             new_estimated_price = 10
-        print('Precio estimado DDDDDDDDD: ', new_estimated_price)
         if isinstance(new_estimated_price, int):
             new_estimated_price = new_estimated_price + 0.001
-        print('Precio estimado FFFFFFFFFF: ', new_estimated_price)
         if not isinstance(new_estimated_price, float):
             raise ValidationError('El precio estimado debe ser un número')
         job.name = new_name

--- a/backend/service/views.py
+++ b/backend/service/views.py
@@ -115,6 +115,10 @@ class JobView(APIView):
         new_estimated_price = job_data['estimated_price']
         if new_estimated_price == '':
             new_estimated_price = 10
+        print('Precio estimado DDDDDDDDD: ', new_estimated_price)
+        if isinstance(new_estimated_price, int):
+            new_estimated_price = new_estimated_price + 0.001
+        print('Precio estimado FFFFFFFFFF: ', new_estimated_price)
         if not isinstance(new_estimated_price, float):
             raise ValidationError('El precio estimado debe ser un número')
         job.name = new_name

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,7 +47,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "postcss": "^8.4.33",
         "tailwindcss": "^3.4.1",
-        "vite": "^5.1.5"
+        "vite": "^5.2.8"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.33",
     "tailwindcss": "^3.4.1",
-    "vite": "^5.1.5"
+    "vite": "^5.2.8"
   },
   "babel": {
     "presets": [

--- a/frontend/src/components/service/CreateJob.jsx
+++ b/frontend/src/components/service/CreateJob.jsx
@@ -39,10 +39,12 @@ export default function CreateService() {
       if (!nameJob.trim()) {
          setErrorNameMessage("El nombre es obligatorio.")
          return
-      }if (/^\d+$/.test(nameJob)) {
+      }
+      if (/^\d+$/.test(nameJob)) {
          setErrorNameMessage("El nombre del trabajo no puede tener solo numeros.")
          return
-      }if(!estimated_price){
+      }
+      if (!estimated_price) {
          setErrorPriceMessage("El precio es obligatorio.")
          return
       }
@@ -56,6 +58,10 @@ export default function CreateService() {
       }
       if (nameJob.length >= 100) {
          setErrorNameMessage("El nombre del trabajo no puede tener mas de 100 caracteres.")
+         return
+      }
+      if(Number.isInteger(Number(estimated_price))){
+         setErrorPriceMessage("El precio debe ser un numero con decimales.")
          return
       }
       createJob(nameJob, Number(estimated_price), serviceId, loggedUser.token)

--- a/frontend/src/components/service/CreateJob.jsx
+++ b/frontend/src/components/service/CreateJob.jsx
@@ -60,10 +60,6 @@ export default function CreateService() {
          setErrorNameMessage("El nombre del trabajo no puede tener mas de 100 caracteres.")
          return
       }
-      if(Number.isInteger(Number(estimated_price))){
-         setErrorPriceMessage("El precio debe ser un numero con decimales.")
-         return
-      }
       createJob(nameJob, Number(estimated_price), serviceId, loggedUser.token)
       setErrorNameMessage("")
       setErrorPriceMessage("")

--- a/frontend/src/components/service/CreateJob.jsx
+++ b/frontend/src/components/service/CreateJob.jsx
@@ -84,6 +84,8 @@ export default function CreateService() {
                      onChange={e => setEstimated_price(e.target.value)}
                      className="px-2 py-1 border rounded"
                   />
+                  <p className="text-gray-500 text-sm">El precio se tiene que escribir con , o .</p>
+                  <p className="text-gray-500 text-sm">Por ejemplo: 2,7 o 2.7</p>
                </div>
                {errorPriceMessage && <p className="text-red-500">{errorPriceMessage}</p>}
                <button type="submit" className="bg-orange-300 rounded px-3 py-1 font-semibold">


### PR DESCRIPTION
Al intentar crear o editar un Job, la aplicación lanza un error arreglado, era fallo provocado al cambiar en Backend el precio de un integer a un double. Se ha añadido una validación para que siempre se introduzca un numero con decimales.