### PR TITLE
Fix 3.22 - Campos dobles en editar servicio /415

### DIFF
--- a/frontend/src/components/service/Service.jsx
+++ b/frontend/src/components/service/Service.jsx
@@ -249,36 +249,6 @@ export default function ServiceDetails() {
                                  (isOnlyCharacters && errorMessages.onlyCharacters)
                               }
                            />
-
-                        <div>
-                           <label htmlFor="profession" className="flex flex-col gap-x-4 text-1.7xl font-semibold">
-                              Profesión:{" "}
-                           </label>
-                           <select
-                              id="profession"
-                              name="profession"
-                              value={profession}
-                              disabled={!isEditing}
-                              onChange={event => setProfession(event.target.value)}
-                              className="pl-2 border rounded w-full md:w-94">
-                              <option>{profession}</option>
-                              {professions.map((prof, index) => (
-                                 <option key={index} value={prof.name}>
-                                    {prof.name}
-                                 </option>
-                              ))}
-                           </select>
-                        </div>
-                        <ServiceData
-                           type={"text"}
-                           formName={"city"}
-                           labelText={"Ciudad:"}
-                           inputValue={city}
-                           isReadOnly={!isEditing}
-                           onChange={event => setCity(event.target.value)}
-                           isError={isRequiredCityError || isCityError}
-                           errorMessage={(isRequiredCityError && errorMessages.required) || (isCityError && errorMessages.cityLength)}
-                        />
                         <ServiceData
                            type={"number"}
                            formName={"experience"}


### PR DESCRIPTION
Antes los campos salian dobles al darle a editar servicio:
![image](https://github.com/ciaolavoro/ciao-lavoro/assets/72520174/6f35dadf-166e-440c-8237-7fb4647afecd)

Ahora salen bien con esta corrección
![image](https://github.com/ciaolavoro/ciao-lavoro/assets/72520174/9f9ce793-b398-40b8-b402-5d1f24a5f033)
